### PR TITLE
add webhook_timeout to ssi-service configuration to fix startup failure

### DIFF
--- a/ssi-service-compose/config.toml
+++ b/ssi-service-compose/config.toml
@@ -57,3 +57,7 @@ name = "manifest"
 
 [services.presentation]
 name = "presentation"
+
+[services.webhook]
+name = "webhook"
+webhook_timeout = "10s"


### PR DESCRIPTION
## Description

Add `webhook_timeout` to the configuration file for `ssi-service`. This value seems to be mandatory, since [this commit](https://github.com/TBD54566975/ssi-service/commit/2dbfc4d32b6dd9679ec819bc79656e2f7a112fa0), because otherwise `ssi-service` does not start when running `docker-compose -f ssi-service-compose/ssi-service-compose.yml up` from the latest image of `ssi-service`, and the following error appears and fails the startup.

```
web_1              | {"error":"time: invalid duration \"\"","level":"error","msg":"parsing webhook timeout","time":"2023-05-12T16:18:31Z"}
web_1              | {"error":"parsing webhook timeout: time: invalid duration \"\"","level":"error","msg":"could not instantiate the webhook service","time":"2023-05-12T16:18:31Z"}
web_1              | {"error":"could not instantiate the webhook service: parsing webhook timeout: time: invalid duration \"\"","level":"error","msg":"could not instantiate the ssi service","time":"2023-05-12T16:18:31Z"}
web_1              | {"level":"fatal","msg":"could not start http services: could not instantiate the ssi service: could not instantiate the webhook service: parsing webhook timeout: time: invalid duration \"\"","time":"2023-05-12T16:18:31Z"}
redis-commander    | listening on 0.0.0.0:8081
redis-commander    | access with browser at http://127.0.0.1:8081
redis-commander    | Redis Connection redis:6379 using Redis DB #0
ssi-service-compose_web_1 exited with code 1
```

Tested by running `docker-compose -f ssi-service-compose/ssi-service-compose.yml up` again and it succeeded after this addition.

